### PR TITLE
Add calledInOrder

### DIFF
--- a/lib/called-in-order.js
+++ b/lib/called-in-order.js
@@ -1,0 +1,34 @@
+"use strict";
+
+var every = require("./prototypes/array").every;
+
+function hasCallsLeft(callMap, spy) {
+    if (callMap[spy.id] === undefined) {
+        callMap[spy.id] = 0;
+    }
+
+    return callMap[spy.id] < spy.callCount;
+}
+
+function checkAdjacentCalls(callMap, spy, index, spies) {
+    var calledBeforeNext = true;
+
+    if (index !== spies.length - 1) {
+        calledBeforeNext = spy.calledBefore(spies[index + 1]);
+    }
+
+    if (hasCallsLeft(callMap, spy) && calledBeforeNext) {
+        callMap[spy.id] += 1;
+        return true;
+    }
+
+    return false;
+}
+
+module.exports = function calledInOrder(spies) {
+    var callMap = {};
+    // eslint-disable-next-line no-underscore-dangle
+    var _spies = arguments.length > 1 ? arguments : spies;
+
+    return every(_spies, checkAdjacentCalls.bind(null, callMap));
+};

--- a/lib/called-in-order.test.js
+++ b/lib/called-in-order.test.js
@@ -1,0 +1,121 @@
+"use strict";
+
+var assert = require("@sinonjs/referee-sinon").assert;
+var calledInOrder = require("./called-in-order");
+var sinon = require("@sinonjs/referee-sinon").sinon;
+
+var testObject1 = {
+    someFunction: function() {
+        return;
+    }
+};
+var testObject2 = {
+    otherFunction: function() {
+        return;
+    }
+};
+var testObject3 = {
+    thirdFunction: function() {
+        return;
+    }
+};
+
+function testMethod() {
+    testObject1.someFunction();
+    testObject2.otherFunction();
+    testObject2.otherFunction();
+    testObject2.otherFunction();
+    testObject3.thirdFunction();
+}
+
+describe("calledInOrder", function() {
+    beforeEach(function() {
+        sinon.stub(testObject1, "someFunction");
+        sinon.stub(testObject2, "otherFunction");
+        sinon.stub(testObject3, "thirdFunction");
+        testMethod();
+    });
+    afterEach(function() {
+        testObject1.someFunction.restore();
+        testObject2.otherFunction.restore();
+        testObject3.thirdFunction.restore();
+    });
+
+    describe("given single array argument", function() {
+        describe("when stubs were called in expected order", function() {
+            it("returns true", function() {
+                assert.isTrue(
+                    calledInOrder([
+                        testObject1.someFunction,
+                        testObject2.otherFunction
+                    ])
+                );
+                assert.isTrue(
+                    calledInOrder([
+                        testObject1.someFunction,
+                        testObject2.otherFunction,
+                        testObject2.otherFunction,
+                        testObject3.thirdFunction
+                    ])
+                );
+            });
+        });
+
+        describe("when stubs were called in unexpected order", function() {
+            it("returns false", function() {
+                assert.isFalse(
+                    calledInOrder([
+                        testObject2.otherFunction,
+                        testObject1.someFunction
+                    ])
+                );
+                assert.isFalse(
+                    calledInOrder([
+                        testObject2.otherFunction,
+                        testObject1.someFunction,
+                        testObject1.someFunction,
+                        testObject3.thirdFunction
+                    ])
+                );
+            });
+        });
+    });
+
+    describe("given multiple arguments", function() {
+        describe("when stubs were called in expected order", function() {
+            it("returns true", function() {
+                assert.isTrue(
+                    calledInOrder(
+                        testObject1.someFunction,
+                        testObject2.otherFunction
+                    )
+                );
+                assert.isTrue(
+                    calledInOrder(
+                        testObject1.someFunction,
+                        testObject2.otherFunction,
+                        testObject3.thirdFunction
+                    )
+                );
+            });
+        });
+
+        describe("when stubs were called in unexpected order", function() {
+            it("returns false", function() {
+                assert.isFalse(
+                    calledInOrder(
+                        testObject2.otherFunction,
+                        testObject1.someFunction
+                    )
+                );
+                assert.isFalse(
+                    calledInOrder(
+                        testObject2.otherFunction,
+                        testObject1.someFunction,
+                        testObject3.thirdFunction
+                    )
+                );
+            });
+        });
+    });
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 module.exports = {
+    calledInOrder: require("./called-in-order"),
     every: require("./every"),
     functionName: require("./function-name"),
     orderByFirstCall: require("./order-by-first-call"),

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -5,6 +5,7 @@ var index = require("./index");
 
 describe("package", function() {
     var expectedExports = [
+        "calledInOrder",
         "every",
         "functionName",
         "orderByFirstCall",


### PR DESCRIPTION
This PR adds [`calledInOrder` from `sinon`](https://github.com/sinonjs/sinon/blob/5cc5dd9b6aa0d282756c3889d1062979ace195c2/lib/sinon/util/core/called-in-order.js).

It has been refactored, with test coverage at 100%.