### PR TITLE
Export className

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
     calledInOrder: require("./called-in-order"),
+    className: require("./class-name"),
     every: require("./every"),
     functionName: require("./function-name"),
     orderByFirstCall: require("./order-by-first-call"),

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -6,6 +6,7 @@ var index = require("./index");
 describe("package", function() {
     var expectedExports = [
         "calledInOrder",
+        "className",
         "every",
         "functionName",
         "orderByFirstCall",


### PR DESCRIPTION
This PR is a followup to #5, it exports the `className` function for easy use in consumers and to discourage use of functions by their file locations