### PR TITLE
Dynamically determine names of exports

### DIFF
--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,20 +1,29 @@
 "use strict";
 
 var assert = require("@sinonjs/referee-sinon").assert;
+var fs = require("fs");
 var index = require("./index");
 
-describe("package", function() {
-    var expectedExports = [
-        "calledInOrder",
-        "className",
-        "every",
-        "functionName",
-        "orderByFirstCall",
-        "prototypes",
-        "typeOf",
-        "valueToString"
-    ];
-    Object.keys(index).forEach(function(name) {
-        assert.isTrue(expectedExports.includes(name));
+// removes extension and camel cases filename
+function filenameToMethod(name) {
+    return name.split(".")[0].replace(/-(.)/g, function(_, chr) {
+        return chr.toUpperCase();
     });
+}
+
+describe("package", function() {
+    fs.readdirSync("./lib")
+        .reduce(function(result, file) {
+            // files that end with .js (excludes dirs) that do not include "index" or ".test"
+            if (/^((?!index|\.test).)*\.js$/.test(file)) {
+                result.push(filenameToMethod(file));
+            }
+
+            return result;
+        }, [])
+        .forEach(function(name) {
+            it("should export: " + name, function() {
+                assert.isFunction(index[name]);
+            });
+        });
 });

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1,29 +1,29 @@
 "use strict";
 
 var assert = require("@sinonjs/referee-sinon").assert;
-var fs = require("fs");
 var index = require("./index");
 
-// removes extension and camel cases filename
-function filenameToMethod(name) {
-    return name.split(".")[0].replace(/-(.)/g, function(_, chr) {
-        return chr.toUpperCase();
-    });
-}
+var expectedMethods = [
+    "calledInOrder",
+    "className",
+    "every",
+    "functionName",
+    "orderByFirstCall",
+    "typeOf",
+    "valueToString"
+];
+var expectedObjectProperties = ["prototypes"];
 
 describe("package", function() {
-    fs.readdirSync("./lib")
-        .reduce(function(result, file) {
-            // files that end with .js (excludes dirs) that do not include "index" or ".test"
-            if (/^((?!index|\.test).)*\.js$/.test(file)) {
-                result.push(filenameToMethod(file));
-            }
-
-            return result;
-        }, [])
-        .forEach(function(name) {
-            it("should export: " + name, function() {
-                assert.isFunction(index[name]);
-            });
+    expectedMethods.forEach(function(name) {
+        it("should export a method named " + name, function() {
+            assert.isFunction(index[name]);
         });
+    });
+
+    expectedObjectProperties.forEach(function(name) {
+        it("should export an object property named " + name, function() {
+            assert.isObject(index[name]);
+        });
+    });
 });


### PR DESCRIPTION
* :warning: `index.test.js` tests were not run at all: 
    `npm test` before this PR: `33 passing (23ms)`
    After this PR: `40 passing (25ms)`
* dynamically determine the name of the exports based on the filenames
* change the logic to use the filenames as the source of truth (expectations) instead of the names exported from `index`

I briefly looked around and failed to find a eslint mocha plugin that would catch a test file with no tests in it. Maybe someone else will have more luck?
