### PR TITLE
Handle falsy values for functionName

### DIFF
--- a/lib/function-name.js
+++ b/lib/function-name.js
@@ -1,6 +1,10 @@
 "use strict";
 
 module.exports = function functionName(func) {
+    if (!func) {
+        return "";
+    }
+
     return (
         func.displayName ||
         func.name ||

--- a/lib/function-name.test.js
+++ b/lib/function-name.test.js
@@ -6,6 +6,12 @@ var refute = require("@sinonjs/referee-sinon").refute;
 var functionName = require("./function-name");
 
 describe("function-name", function() {
+    it("should return empty string if func is falsy", function() {
+        jsc.assertForall("falsy", function(fn) {
+            return functionName(fn) === "";
+        });
+    });
+
     it("should use displayName by default", function() {
         jsc.assertForall("nestring", function(displayName) {
             var fn = { displayName: displayName };


### PR DESCRIPTION
sinonjs/formatio recently publish a [change](https://github.com/sinonjs/formatio/commit/07e2b54e573a199b1006dd223160c66bca3eb870) where it started using sinonjs/commons' functionName, and with it comes the lack of handling falsy values for functionName argument. It started failing some of the tests in our project.