### PR TITLE
Emit deprecation warnings in node through process.emitWarning

### DIFF
--- a/lib/deprecated.js
+++ b/lib/deprecated.js
@@ -46,13 +46,13 @@ exports.defaultMsg = function(packageName, funcName) {
  * @returns {undefined}
  */
 exports.printWarning = function(msg) {
-    // Watch out for IE7 and below! :(
     /* istanbul ignore next */
-    if (typeof console !== "undefined") {
-        if (console.info) {
-            console.info(msg);
-        } else {
-            console.log(msg);
-        }
+    if (typeof process === "object" && process.emitWarning) {
+        // Emit Warnings in Node
+        process.emitWarning(msg);
+    } else if (console.info) {
+        console.info(msg);
+    } else {
+        console.log(msg);
     }
 };

--- a/lib/deprecated.test.js
+++ b/lib/deprecated.test.js
@@ -19,16 +19,30 @@ describe("deprecated", function() {
     });
 
     describe("printWarning", function() {
-        describe("when `console` is defined", function() {
+        beforeEach(function() {
+            sinon.replace(process, "emitWarning", sinon.fake());
+        });
+
+        afterEach(sinon.restore);
+
+        describe("when `process.emitWarning` is defined", function() {
+            it("should call process.emitWarning with a msg", function() {
+                deprecated.printWarning(msg);
+                assert.calledOnceWith(process.emitWarning, msg);
+            });
+        });
+
+        describe("when `process.emitWarning` is undefined", function() {
             beforeEach(function() {
                 sinon.replace(console, "info", sinon.fake());
                 sinon.replace(console, "log", sinon.fake());
+                process.emitWarning = undefined;
             });
 
             afterEach(sinon.restore);
 
             describe("when `console.info` is defined", function() {
-                it("shoudl call `console.info` with a message", function() {
+                it("should call `console.info` with a message", function() {
                     deprecated.printWarning(msg);
                     assert.calledOnceWith(console.info, msg);
                 });


### PR DESCRIPTION
Close: #36 

## Changes
- [x] Ditch `console` check
- [x] Use `process.emitWarning` to print out deprecation warnings in node
- [x] Refactor `printWarning` tests to match the new approach

## Verify
- Run `npm run test`
- All tests should pass