### PR TITLE
Fix generators causing exceptions in function-name

### DIFF
--- a/lib/function-name.js
+++ b/lib/function-name.js
@@ -11,13 +11,19 @@ module.exports = function functionName(func) {
         return "";
     }
 
-    return (
-        func.displayName ||
-        func.name ||
-        // Use function decomposition as a last resort to get function
-        // name. Does not rely on function decomposition to work - if it
-        // doesn't debugging will be slightly less informative
-        // (i.e. toString will say 'spy' rather than 'myFunc').
-        (String(func).match(/function ([^\s(]+)/) || [])[1]
-    );
+    try {
+        return (
+            func.displayName ||
+            func.name ||
+            // Use function decomposition as a last resort to get function
+            // name. Does not rely on function decomposition to work - if it
+            // doesn't debugging will be slightly less informative
+            // (i.e. toString will say 'spy' rather than 'myFunc').
+            (String(func).match(/function ([^\s(]+)/) || [])[1]
+        );
+    } catch (e) {
+        // Stringify may fail and we might get an exception, as a last-last
+        // resort fall back to empty string.
+        return "";
+    }
 };

--- a/lib/function-name.test.js
+++ b/lib/function-name.test.js
@@ -52,4 +52,25 @@ describe("function-name", function() {
             functionName(fn);
         });
     });
+
+    it("should not fail when toString is undefined", function() {
+        refute.exception(function() {
+            functionName(Object.create(null));
+        });
+    });
+
+    it("should not fail when toString throws", function() {
+        refute.exception(function() {
+            var fn;
+            try {
+                // eslint-disable-next-line no-eval
+                fn = eval("(function*() {})")().constructor;
+            } catch (e) {
+                // env doesn't support generators
+                return;
+            }
+
+            functionName(fn);
+        });
+    });
 });


### PR DESCRIPTION
`String(x)` fails in objects if an object's toString() method throws or if it doesn't exist. This is also exhibited when determining the name of `Object.create(null)`, however I encountered the issue with generators. It has toString defined, but calling it will always fail.