### PR TITLE
Add .d.ts files to package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ typings/
 
 # next.js build output
 .next
+types

--- a/package-lock.json
+++ b/package-lock.json
@@ -3746,6 +3746,12 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "dev": true
+    },
     "typify-parser": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/typify-parser/-/typify-parser-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "version": "1.8.1",
   "description": "Simple functions shared among the sinon end user libraries",
   "main": "lib/index.js",
+  "types": "./types/index.d.ts",
   "scripts": {
+    "build": "rm -rf types && tsc",
     "lint": "eslint .",
     "precommit": "lint-staged",
     "test": "mocha --recursive -R dot \"lib/**/*.test.js\"",
     "test-check-coverage": "npm run test-coverage && nyc check-coverage --branches 100 --functions 100 --lines 100",
     "test-coverage": "nyc --reporter text --reporter html --reporter lcovonly npm run test",
+    "prepublishOnly": "npm run build",
     "preversion": "npm run test-check-coverage",
     "version": "changes --commits --footer",
     "postversion": "git push --follow-tags && npm publish"
@@ -18,7 +21,8 @@
     "url": "git+https://github.com/sinonjs/commons.git"
   },
   "files": [
-    "lib"
+    "lib",
+    "types"
   ],
   "author": "",
   "license": "BSD-3-Clause",
@@ -48,7 +52,8 @@
     "lint-staged": "10.1.1",
     "mocha": "7.1.0",
     "nyc": "15.0.0",
-    "prettier": "^1.14.3"
+    "prettier": "^1.14.3",
+    "typescript": "^4.1.3"
   },
   "dependencies": {
     "type-detect": "4.0.8"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "include": [
+      "lib/*.js"
+  ],
+  "exclude" : [
+    "lib/*.test.js"
+  ],
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "allowJs": true,
+    "outDir": "types"
+  }
+}


### PR DESCRIPTION
In order to improve the experience of TypeScript users, we are compiling
`.d.ts` files from the JSDoc and distributing them with the package

#### Background

* We'd like to ship the library with `.d.ts` files, to allow improved experience for TypeScript users

#### Solution

* Create `.d.ts` files from the source files

#### How to verify

1. Check out this branch
1. `npm ci`
1. `npm run build`
1. Observe that there are `.d.ts` files in the `types/` folder
2. `npm pack`
3. Observe that the `.d.ts` files are included in the package
4. `npm link`
5. In a `sinon` checkout:
    1.  `npm link @sinonjs/commons`
    2. `npm test`
    3. Observe that tests still pass