### PR TITLE
Fix #89: detect error on access to __proto__

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,4 +100,6 @@ jobs:
               env:
                   HUSKY_SKIP_INSTALL: 1
             - name: npm test
-              run: npm test
+              run: |
+                  npm test
+                  npm test --disable-proto=throw

--- a/lib/prototypes/copy-prototype-methods.js
+++ b/lib/prototypes/copy-prototype-methods.js
@@ -1,6 +1,22 @@
 "use strict";
 
 var call = Function.call;
+var throwsOnProto = require("./throws-on-proto");
+
+var disallowedProperties = [
+    // ignore size because it throws from Map
+    "size",
+    "caller",
+    "callee",
+    "arguments",
+];
+
+// This branch is covered when tests are run with `--disable-proto=throw`,
+// however we can test both branches at the same time, so this is ignored
+/* istanbul ignore next */
+if (throwsOnProto) {
+    disallowedProperties.push("__proto__");
+}
 
 module.exports = function copyPrototypeMethods(prototype) {
     // eslint-disable-next-line @sinonjs/no-prototype-methods/no-prototype-methods
@@ -8,16 +24,15 @@ module.exports = function copyPrototypeMethods(prototype) {
         result,
         name
     ) {
-        // ignore size because it throws from Map
-        if (
-            name !== "size" &&
-            name !== "caller" &&
-            name !== "callee" &&
-            name !== "arguments" &&
-            typeof prototype[name] === "function"
-        ) {
-            result[name] = call.bind(prototype[name]);
+        if (disallowedProperties.includes(name)) {
+            return result;
         }
+
+        if (typeof prototype[name] !== "function") {
+            return result;
+        }
+
+        result[name] = call.bind(prototype[name]);
 
         return result;
     },

--- a/lib/prototypes/index.test.js
+++ b/lib/prototypes/index.test.js
@@ -8,6 +8,7 @@ var mapProto = require("./index").map;
 var objectProto = require("./index").object;
 var setProto = require("./index").set;
 var stringProto = require("./index").string;
+var throwsOnProto = require("./throws-on-proto");
 
 describe("prototypes", function () {
     describe(".array", function () {
@@ -37,16 +38,19 @@ describe("prototypes", function () {
 });
 
 function verifyProperties(p, origin) {
+    var disallowedProperties = ["size", "caller", "callee", "arguments"];
+    if (throwsOnProto) {
+        disallowedProperties.push("__proto__");
+    }
+
     it("should have all the methods of the origin prototype", function () {
         var methodNames = Object.getOwnPropertyNames(origin.prototype).filter(
             function (name) {
-                return (
-                    name !== "size" &&
-                    name !== "caller" &&
-                    name !== "callee" &&
-                    name !== "arguments" &&
-                    typeof origin.prototype[name] === "function"
-                );
+                if (disallowedProperties.includes(name)) {
+                    return false;
+                }
+
+                return typeof origin.prototype[name] === "function";
             }
         );
 

--- a/lib/prototypes/throws-on-proto.js
+++ b/lib/prototypes/throws-on-proto.js
@@ -1,0 +1,26 @@
+"use strict";
+
+/**
+ * Is true when the environment causes an error to be thrown for accessing the
+ * __proto__ property.
+ *
+ * This is necessary in order to support `node --disable-proto=throw`.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto
+ *
+ * @type {boolean}
+ */
+let throwsOnProto;
+try {
+    const object = {};
+    // eslint-disable-next-line no-proto, no-unused-expressions
+    object.__proto__;
+    throwsOnProto = false;
+} catch (_) {
+    // This branch is covered when tests are run with `--disable-proto=throw`,
+    // however we can test both branches at the same time, so this is ignored
+    /* istanbul ignore next */
+    throwsOnProto = true;
+}
+
+module.exports = throwsOnProto;


### PR DESCRIPTION
This PR fixes #89 by detecting whether or not the environment throws when accessing the `__proto__` property, which has been deprecated.

See:
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto
* https://nodejs.org/api/all.html#all_cli_--disable-protomode

I realise that we should probably do some refactoring in `copy-prototype.js` and make that whole area nicer ... I'll do that in a separate PR on another day.