### PR TITLE
[Fix] use `indexOf` instead of `includes`

### DIFF
--- a/lib/prototypes/copy-prototype-methods.js
+++ b/lib/prototypes/copy-prototype-methods.js
@@ -24,7 +24,7 @@ module.exports = function copyPrototypeMethods(prototype) {
         result,
         name
     ) {
-        if (disallowedProperties.includes(name)) {
+        if (disallowedProperties.indexOf(name) > -1) {
             return result;
         }
 


### PR DESCRIPTION
Fixes #99.

It would be even better to add node 4 to the testing matrix.