### PR TITLE
Prefer ES2017

### DIFF
--- a/lib/prototypes/copy-prototype-methods.js
+++ b/lib/prototypes/copy-prototype-methods.js
@@ -24,7 +24,7 @@ module.exports = function copyPrototypeMethods(prototype) {
         result,
         name
     ) {
-        if (disallowedProperties.indexOf(name) > -1) {
+        if (disallowedProperties.includes(name)) {
             return result;
         }
 


### PR DESCRIPTION
This restores the implementation of v1.8.4, preferring to use `Array.prototype.includes`.

This effectively drops support for ES5, so we'll release this as a new MAJOR release to not have it used by legacy Sinon packages.