### PR TITLE
Fix ES5 compatibility: revert from template string to concatenation

### DIFF
--- a/lib/deprecated.js
+++ b/lib/deprecated.js
@@ -28,8 +28,15 @@ exports.wrap = function (func, msg) {
  * @param  {string} funcName
  * @returns {string}
  */
-exports.defaultMsg = function (packageName, funcName) {
-    return `${packageName}.${funcName} is deprecated and will be removed from the public API in a future version of ${packageName}.`;
+exports.defaultMsg = function(packageName, funcName) {
+    return (
+        packageName +
+        "." +
+        funcName +
+        " is deprecated and will be removed from the public API in a future version of " +
+        packageName +
+        "."
+    );
 };
 
 /**


### PR DESCRIPTION
Current v1.x version does not work in IE11 and producing following error:
```
IE 11.0 (Windows 7) ERROR
    Invalid character
    at webpack:///***/*******_****/*********/*-***-***_*****_******/node_modules/@sinonjs/commons/lib/deprecated.js:32:1 <- /tmp/79-karma-shim793pa3AAH16JZI.js:1039:12
```
Using string concatenation instead of template literal should fix.