### PR TITLE
Fix ES5 compatibility: revert from template string to concatenation

### DIFF
--- a/lib/deprecated.js
+++ b/lib/deprecated.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, prefer-template */
 "use strict";
 
 /**
@@ -29,7 +29,14 @@ exports.wrap = function (func, msg) {
  * @returns {string}
  */
 exports.defaultMsg = function (packageName, funcName) {
-    return `${packageName}.${funcName} is deprecated and will be removed from the public API in a future version of ${packageName}.`;
+    return (
+        packageName +
+        "." +
+        funcName +
+        " is deprecated and will be removed from the public API in a future version of " +
+        packageName +
+        "."
+    );
 };
 
 /**


### PR DESCRIPTION
This fix has been cherry picked from https://github.com/sinonjs/commons/pull/102, so the original author is given proper credit in the git history.