### PR TITLE
chore: remove obsolete IE11 code

### DIFF
--- a/lib/class-name.js
+++ b/lib/class-name.js
@@ -1,26 +1,13 @@
 "use strict";
 
-var functionName = require("./function-name");
-
 /**
  * Returns a display name for a value from a constructor
  * @param  {object} value A value to examine
  * @returns {(string|null)} A string or null
  */
 function className(value) {
-    return (
-        (value.constructor && value.constructor.name) ||
-        // The next branch is for IE11 support only:
-        // Because the name property is not set on the prototype
-        // of the Function object, we finally try to grab the
-        // name from its definition. This will never be reached
-        // in node, so we are not able to test this properly.
-        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name
-        (typeof value.constructor === "function" &&
-            /* istanbul ignore next */
-            functionName(value.constructor)) ||
-        null
-    );
+    const name = value.constructor && value.constructor.name;
+    return name || null;
 }
 
 module.exports = className;


### PR DESCRIPTION
When we upgraed to @sinonjs/eslint-config@4 in
09e99f4e310c20408df50330124e4d68a60e9b6a we effectively removed support for IE11.

That means that this code branch is obsolete and is safe to remove.

I'm marking this as a `patch` version, as we are not breaking anything for anyone.